### PR TITLE
All Network Deployments

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -1,8 +1,16 @@
 {
   "HooksTrampoline": {
+    "1": {
+      "address": "0x01DcB88678aedD0C4cC9552B20F4718550250574",
+      "transactionHash": "0xf6b98f2bf33cf420fa657b5475c08a8c9c871f9707705bcbbcca194c35832bea"
+    },
     "5": {
-      "address": "0xFCF4E1ffd4C778c358f371B9a624b28386b4ecAB",
-      "transactionHash": "0x324e1b735fdec8c1e168c9b3860f7153ad7de0c9d1ffdc7ccbe47f5c3d827cd8"
+      "address": "0x01DcB88678aedD0C4cC9552B20F4718550250574",
+      "transactionHash": "0x1e93fc29903de1a502fa99fe1c9b772de5dd7cc5868a9926f7a8433150b9a8a0"
+    },
+    "100": {
+      "address": "0xD49Fa4e610d489aB98008bC4424B9F7276fF34bA",
+      "transactionHash": "0x7c09cad0f4a6855ecf6c07950d6508648a2b596a6053bfa1db0d551aaf6a8ade"
     }
   }
 }

--- a/networks.json
+++ b/networks.json
@@ -9,8 +9,8 @@
       "transactionHash": "0x1e93fc29903de1a502fa99fe1c9b772de5dd7cc5868a9926f7a8433150b9a8a0"
     },
     "100": {
-      "address": "0xD49Fa4e610d489aB98008bC4424B9F7276fF34bA",
-      "transactionHash": "0x7c09cad0f4a6855ecf6c07950d6508648a2b596a6053bfa1db0d551aaf6a8ade"
+      "address": "0x01DcB88678aedD0C4cC9552B20F4718550250574",
+      "transactionHash": "0x39ac919f95fed1085967b196908f727dc1ee8bb9708e1ee070ea7fc45ed0605d"
     }
   }
 }


### PR DESCRIPTION
This PR adds new deployments for the `HooksTrampoline` contract.

~~**Note the different address on Gnosis Chain!** This is because currently does not implement <https://eips.ethereum.org/EIPS/eip-3855> (the `PUSH0` opcode), which is emitted by default with the Solidity Compiler version 0.8.20. This required me to downgrade the EVM version to the previous hardfork (`paris`, where there are other HFs since then, but that was the last one that changed EVM bytecodes). Since the emitted code is different, the final contract address is also different.~~

**Edit (2023-08-25)**: Since the Shapella hardfork is now live, Gnosis Chain supports the `PUSH0` opcode, and the hooks trampoline contract now lands on the exact same address as the other networks 🎉.

### Test Plan

Check out:

- <https://etherscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574>
- <https://goerli.etherscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574>
- ~~<https://gnosisscan.io/address/0xD49Fa4e610d489aB98008bC4424B9F7276fF34bA>~~ <https://gnosisscan.io/address/0x01DcB88678aedD0C4cC9552B20F4718550250574>