### PR TITLE
Add Sepoplia deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,46 @@ sequenceDiagram
     Settlement->>Solver: return
     deactivate Settlement
 ```
+
+## Development
+
+### Installation
+
+This project uses [Foundry](https://book.getfoundry.sh/).
+
+Additional dependencies can be installed with:
+
+```sh
+forge install
+```
+
+### Test
+
+```sh
+forge test
+```
+
+### Deployment
+
+Copy `.env.sample` to `.env` and fill each variable with the necessary
+information.
+
+You can do a test run of the transaction with the following command:
+
+```sh
+source .env
+forge script script/DeployHooksTrampoline.s.sol -vvvv --rpc-url "$ETH_RPC_URL"
+```
+
+The following command executes the deployment transaction onchain and verifies
+the contract code on the block explorer.
+
+```sh
+source .env
+forge script script/DeployHooksTrampoline.s.sol -vvvv --rpc-url "$ETH_RPC_URL" --verify --broadcast
+```
+
+This contract uses deterministic deployments.
+The official deployment addresses for all supported chains can be found in the
+file `networks.json`.
+Entries are manually added to that file after each deployment to a new chain.

--- a/networks.json
+++ b/networks.json
@@ -11,6 +11,10 @@
     "100": {
       "address": "0x01DcB88678aedD0C4cC9552B20F4718550250574",
       "transactionHash": "0x39ac919f95fed1085967b196908f727dc1ee8bb9708e1ee070ea7fc45ed0605d"
+    },
+    "11155111": {
+      "address": "0x01DcB88678aedD0C4cC9552B20F4718550250574",
+      "transactionHash": "0xd8259e124d6a947fffc4981d90d6eb60ebf1e45cb4c559c79a5aecb4dae91675"
     }
   }
 }


### PR DESCRIPTION
Adds the Sepolia deployment to `networks.json` to make it official and adds simple instructions on how to deploy.

### Test plan

You can check the deployed contract code [on Etherscan](https://sepolia.etherscan.io/address/0x01dcb88678aedd0c4cc9552b20f4718550250574#code). Note as well that the deployment address is the same as mainnet.