### PR TITLE
Account for unsent 1/64th of gas in call

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,10 +3,6 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
-# In isolation mode all top-level calls are executed as a separate transaction in a separate EVM
-# context, enabling more precise gas accounting and transaction state changes
-isolate = true
-
 solc = "0.8.20"
 evm-version = "shanghai"
 optimizer = true

--- a/test/GasLimitEnforcement.t.sol
+++ b/test/GasLimitEnforcement.t.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8;
 
-import "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {HooksTrampoline} from "../src/HooksTrampoline.sol";
-
-import {console} from "forge-std/console.sol";
 
 contract GasLimitEnforcementTest is Test {
     address public settlement;
@@ -13,8 +11,33 @@ contract GasLimitEnforcementTest is Test {
     GasCraver public gasCraver;
 
     uint256 constant CRAVED_GAS = 1_000_000;
-    uint256 constant EXTRA_GAS = 12_000;
+    /// @dev This constant captures the fact that the trampoline executes a few
+    /// operations before calling the desired contract. This means that if we
+    /// want to forward some gas to the hook target, the call to the trampoline
+    /// also needs to include this extra overhead. The amount is tentative and
+    /// depends on the executed call, so it can only be approximately
+    /// determined.
+    uint256 constant TRAMPOLINE_OVERHEAD = 4_000;
+    /// @dev The gas craver contract has some minimal overhead before checking
+    /// the gas used in the call. The amount is exact and derived from the
+    /// debugger.
+    uint256 constant GAS_CRAVER_OVERHEAD = 117;
+    /// @dev A bound on how much actual gas is spent when executing the function
+    /// in the gas craver contract.
     uint256 constant BOUND_ON_GAS_COST = 60_000;
+
+    /// @dev When a function is called, only part of the gas is forwarded to the
+    /// called contract. Since we're testing gas amounts, we want to make sure
+    /// all calls in the tests are being given more than enough gas to be called
+    /// with the amount of gas specified in the call (`call{gas: ...}`).
+    modifier gasPadded() {
+        _;
+        // This require statement is here to make the test gas estimation use
+        // a larger gas limit than needed for executing the test. We assume that
+        // the calls in the test will use less than the amount of gas in the
+        // right-hand side of the inequality.
+        require(gasleft() > 42 * CRAVED_GAS, "Foundry gas estimation failed");
+    }
 
     function setUp() public {
         settlement = 0x4242424242424242424242424242424242424242;
@@ -22,16 +45,16 @@ contract GasLimitEnforcementTest is Test {
         gasCraver = new GasCraver(CRAVED_GAS);
     }
 
-    function test_GasCraverDirectExecutionSuccess() public {
-        // WHEN: we call the gasCraver with the extra gas
-        gasCraver.foo{gas: CRAVED_GAS + EXTRA_GAS}();
+    function test_GasCraverDirectExecutionSuccess() public gasPadded {
+        // WHEN: we call the gasCraver with the call overhead
+        gasCraver.foo{gas: CRAVED_GAS + GAS_CRAVER_OVERHEAD}();
 
         // THEN: the gasCraver should succeed
         assertEq(gasCraver.stateChanged(), true);
     }
 
-    function test_GasCraverDirectExecutionFailure() public {
-        // WHEN: we call the gasCraver without extra gas
+    function test_GasCraverDirectExecutionFailure() public gasPadded {
+        // WHEN: we call the gasCraver without call overhead
         vm.expectRevert("I want more gas");
         gasCraver.foo{gas: CRAVED_GAS}();
 
@@ -39,52 +62,75 @@ contract GasLimitEnforcementTest is Test {
         assertEq(gasCraver.stateChanged(), false);
     }
 
-    function test_TrampolineWithSufficientGas() public {
-        // GIVEN: a hook with a gasLimit that includes the extra gas
-        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + EXTRA_GAS);
+    function test_TrampolineWithSufficientGas() public gasPadded {
+        // GIVEN: a hook with a gasLimit that includes the call overhead
+        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + GAS_CRAVER_OVERHEAD);
 
-        // WHEN: we execute the trampoline with double the extra gas
+        // WHEN: we execute the trampoline with double the call overhead
         vm.prank(settlement);
-        trampoline.execute{gas: CRAVED_GAS + 2 * EXTRA_GAS}(hooks);
+        trampoline.execute{gas: limitForForwarding(CRAVED_GAS + GAS_CRAVER_OVERHEAD)}(hooks);
 
         // THEN: the gasCraver should succeed
         assertEq(gasCraver.stateChanged(), true, "Hook should execute successfully");
     }
 
-    function test_TrampolineWithInsufficientHookGasLimit() public {
+    function test_TrampolineWithInsufficientHookGasLimit() public gasPadded {
         // GIVEN: a hook with a gasLimit that is less than the extra gas
-        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS - EXTRA_GAS);
+        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS - GAS_CRAVER_OVERHEAD);
 
         // WHEN: we execute the trampoline with the extra gas
         vm.prank(settlement);
-        trampoline.execute{gas: CRAVED_GAS + EXTRA_GAS}(hooks);
+        trampoline.execute{gas: limitForForwarding(CRAVED_GAS + GAS_CRAVER_OVERHEAD)}(hooks);
 
         // THEN: the gasCraver should fail
         assertEq(gasCraver.stateChanged(), false, "Hook should fail due to insufficient gas limit");
     }
 
-    function test_TrampolineWithInsufficientAvailableGas() public {
+    function test_TrampolineWithInsufficientAvailableGas() public gasPadded {
         // GIVEN: a hook with a gasLimit that includes the extra gas
-        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + EXTRA_GAS);
+        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + GAS_CRAVER_OVERHEAD);
 
         // WHEN: we execute the trampoline without the extra gas
         // THEN: the it should revert with NotEnoughGas
         vm.prank(settlement);
         vm.expectRevert(HooksTrampoline.NotEnoughGas.selector);
-        trampoline.execute{gas: CRAVED_GAS - EXTRA_GAS}(hooks);
+        trampoline.execute{gas: limitForForwarding(CRAVED_GAS + GAS_CRAVER_OVERHEAD) - TRAMPOLINE_OVERHEAD}(hooks);
 
         // THEN: the gasCraver should not execute
         assertEq(gasCraver.stateChanged(), false, "Hook should not execute");
     }
 
-    function test_TrampolineGasEfficiency() public {
-        // GIVEN: a hook with a gasLimit that includes the extra gas
-        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + EXTRA_GAS);
+    /// @dev This test shows an undesired behavior of the trampoline contract.
+    /// It comes from the fact that we can't exactly say in the trampoline how
+    /// much gas is forwarded in the call exactly and so it can't enforce that
+    /// the amount in the call is exactly the desired amount. This is visible
+    /// in the following test, where ideally the trampoline execution would
+    /// revert.
+    /// If this test reverts, try to adjust the critical amount, the valid range
+    /// at the time of writing is ~500 < criticalAmount < ~3000.
+    function test_undesiredBehavior_TrampolineWithInsufficientAvailableGas() public gasPadded {
+        uint256 criticalAmount = 3000;
 
-        // WHEN: we execute the trampoline with double the extra gas
+        // GIVEN: a hook with a gasLimit that includes the call overhead
+        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + GAS_CRAVER_OVERHEAD);
+
+        // WHEN: we execute the trampoline without the call overhead
+        // THEN: it (surprisingly) succeeds
+        vm.prank(settlement);
+        trampoline.execute{gas: limitForForwarding(CRAVED_GAS + GAS_CRAVER_OVERHEAD) - criticalAmount}(hooks);
+
+        // THEN: despite that, the gasCraver does not execute
+        assertEq(gasCraver.stateChanged(), false, "Hook does not execute");
+    }
+
+    function test_TrampolineGasEfficiency() public gasPadded {
+        // GIVEN: a hook with a gasLimit that includes the call overhead
+        HooksTrampoline.Hook[] memory hooks = createHook(CRAVED_GAS + GAS_CRAVER_OVERHEAD);
+
+        // WHEN: we execute the trampoline with double the call overhead
         vm.prank(settlement);
         uint256 gasMetering = gasleft();
-        trampoline.execute{gas: CRAVED_GAS + 2 * EXTRA_GAS}(hooks);
+        trampoline.execute{gas: limitForForwarding(CRAVED_GAS + GAS_CRAVER_OVERHEAD)}(hooks);
         gasMetering -= gasleft();
 
         // THEN: the gasCraver should execute
@@ -105,37 +151,12 @@ contract GasLimitEnforcementTest is Test {
         return hooks;
     }
 
-    // This test demonstrates that Solidity calls reserve 1/64th of available gas
-    // and the called contract receives less gas than what was specified.
-    //
-    // This is important because it means we need to account for this reservation
-    // when setting gas limits for hooks, otherwise they may fail unexpectedly.
-    function test_DemonstratesOneSixtyFourthGasReservation() public {
-        GasRecorder gasRecorder = new GasRecorder();
-
-        // Use a large gas limit to make the 1/64th reservation more noticeable
-        uint256 largeGasLimit = 10_000_000; // 10M gas
-        uint256 expectedReservation = largeGasLimit / 64; // Expected gas reservation 1/64th of the gas limit
-
-        HooksTrampoline.Hook[] memory hooks = new HooksTrampoline.Hook[](1);
-        hooks[0] = HooksTrampoline.Hook({
-            target: address(gasRecorder),
-            callData: abi.encodeCall(GasRecorder.record, ()),
-            gasLimit: largeGasLimit - expectedReservation
-        });
-
-        vm.prank(settlement);
-        trampoline.execute{gas: largeGasLimit}(hooks);
-
-        uint256 actualGasReceived = gasRecorder.value();
-        uint256 expectedGasReceived = largeGasLimit - expectedReservation;
-
-        // The actual gas received should be similar to the expected
-        assertApproxEqAbs(actualGasReceived, expectedGasReceived, 6000);
-
-        emit log_named_uint("TX gas limit", largeGasLimit);
-        emit log_named_uint("Actual gas received", actualGasReceived);
-        emit log_named_uint("Expected gas received", expectedGasReceived);
+    /// @dev The CALL opcode forwards at most 63/64th of the gas left, meaning
+    /// that if we want to forward `gas` in a trampolined call then we need to
+    /// account for that. Also, before the trampolined call the trampoline
+    /// contract execute extra operations that have their own overhead.
+    function limitForForwarding(uint256 gas) private pure returns (uint256) {
+        return (gas + TRAMPOLINE_OVERHEAD) * 64 / 63;
     }
 }
 
@@ -155,13 +176,5 @@ contract GasCraver {
 
     function reset() external {
         stateChanged = false;
-    }
-}
-
-contract GasRecorder {
-    uint256 public value;
-
-    function record() external {
-        value = gasleft();
     }
 }

--- a/test/HooksTrampoline.t.sol
+++ b/test/HooksTrampoline.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8;
 
-import "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {HooksTrampoline} from "../src/HooksTrampoline.sol";
 
@@ -94,7 +94,6 @@ contract HooksTrampolineTest is Test {
         assertEq(order.count(), hooks.length);
     }
 
-    /// forge-config: default.isolate = false
     function test_HandlesOutOfGas() public {
         Hummer hummer = new Hummer();
 
@@ -114,7 +113,6 @@ contract HooksTrampolineTest is Test {
         assertApproxEqAbs(gasUsed, hooks[0].gasLimit + callOverhead, 500);
     }
 
-    /// forge-config: default.isolate = true
     function test_RevertsWhenNotEnoughGas() public {
         uint256 requiredGas = 100_000;
         Hummer hummer = new Hummer();
@@ -127,7 +125,9 @@ contract HooksTrampolineTest is Test {
         });
 
         // Limit the available gas to be less than what the hook requires
-        uint256 limitedGas = requiredGas - 1; // 1 gas unit less than required
+        // Note: the test passes also for slightly higher amounts of `limitedGas` because a
+        // bit of gas is consumed before the gas check is performed.
+        uint256 limitedGas = requiredGas - 1;
 
         vm.prank(settlement);
         vm.expectRevert(HooksTrampoline.NotEnoughGas.selector);
@@ -148,7 +148,7 @@ contract HooksTrampolineTest is Test {
         uint256 totalRequiredGas = requiredGas * hooks.length;
         // Note: the test passes also for slightly higher amounts of `limitedGas` because a
         // bit of gas is consumed before the gas check is performed.
-        uint256 limitedGas = totalRequiredGas;
+        uint256 limitedGas = totalRequiredGas - 1;
 
         vm.prank(settlement);
         vm.expectRevert(HooksTrampoline.NotEnoughGas.selector);


### PR DESCRIPTION
Suggestions from my review of #14.

Main differences:
- Better documentation.
- Account for unsent 63/64th in the trampoline.
- No `isolate = true` anymore, use `gasPadded` instead.
- In test, separate overhead of trampoline with that of the gas craver.
- Remove demonstration of known behavior, in its stead add a test presenting the case where the trampoline contract doesn't forward the desired amount of gas (undesired behavior).